### PR TITLE
paginate-as-record - Changed Paginate Union type to record alias

### DIFF
--- a/src/Paginate.elm
+++ b/src/Paginate.elm
@@ -44,8 +44,11 @@ import Number.Bounded as Bounded exposing (Bounded)
 
 {-| The `PaginatedList` type wraps your `list` and holds all of the information necessary to track pagination.  It does not modify your list in any way (unless you call `Paginate.map`).
 -}
-type PaginatedList a
-    = PaginatedList { itemsPerPage : Int, currentPage : Bounded Int, items : List a }
+type alias PaginatedList a =
+    { itemsPerPage : Int
+    , currentPage : Bounded Int
+    , items : List a
+    }
 
 
 {-| Create a new paginated list.  Pass it the desired number of items per page and the list of items to be paginated.  The current page is always initialized to 1.  The minimum number of items per page is 1.  The minimum number of total pages is 1 (even if you pass in an empty list).
@@ -64,11 +67,10 @@ fromList itemsPerPage items =
             else
                 ceiling <| toFloat (List.length items) / toFloat (Basics.max 1 itemsPerPage)
     in
-        PaginatedList
-            { itemsPerPage = Basics.max 1 itemsPerPage
-            , currentPage = Bounded.between 1 max
-            , items = items
-            }
+        { itemsPerPage = Basics.max 1 itemsPerPage
+        , currentPage = Bounded.between 1 max
+        , items = items
+        }
 
 
 {-| Transform the list inside the `PaginatedList` by providing a function to apply to the wrapped list.  This is how you map, filter, sort and update items in the paginated list.  If this function changes the length of the list, the pagination calculations will be updated accordingly.  If the newly calculated number of pages is less than the current page, the current page will be set to the new last page.
@@ -88,38 +90,38 @@ fromList itemsPerPage items =
 
 -}
 map : (List a -> List a) -> PaginatedList a -> PaginatedList a
-map f (PaginatedList { currentPage, itemsPerPage, items }) =
-    fromList itemsPerPage (f items)
-        |> goTo (Bounded.value currentPage)
+map f p =
+    fromList p.itemsPerPage (f p.items)
+        |> goTo (Bounded.value p.currentPage)
 
 
 {-| Change the paging size.  The total number of pages will be updated accordingly, and the current page will remain unchanged if possible.  If the newly calculated number of pages is less than the current page, the current page will be set to the new last page.  The minimum paging size is 1 item per page.
 -}
 changeItemsPerPage : Int -> PaginatedList a -> PaginatedList a
-changeItemsPerPage newItemsPerPage (PaginatedList { currentPage, items }) =
-    fromList newItemsPerPage items
-        |> goTo (Bounded.value currentPage)
+changeItemsPerPage newItemsPerPage p =
+    fromList newItemsPerPage p.items
+        |> goTo (Bounded.value p.currentPage)
 
 
 {-| Set the current page directly.  If the specified page is "out of bounds" of the paginated list, it will be set to the first or last page accordingly.
 -}
 goTo : Int -> PaginatedList a -> PaginatedList a
-goTo i (PaginatedList p) =
-    PaginatedList { p | currentPage = Bounded.set i p.currentPage }
+goTo i p =
+    { p | currentPage = Bounded.set i p.currentPage }
 
 
 {-| Go to the next page.  Has no effect if you are already on the last page.
 -}
 next : PaginatedList a -> PaginatedList a
-next (PaginatedList p) =
-    PaginatedList { p | currentPage = Bounded.inc 1 p.currentPage }
+next p =
+    { p | currentPage = Bounded.inc 1 p.currentPage }
 
 
 {-| Go to the previous page.  Has no effect if you are already on the first page.
 -}
 prev : PaginatedList a -> PaginatedList a
-prev (PaginatedList p) =
-    PaginatedList { p | currentPage = Bounded.dec 1 p.currentPage }
+prev p =
+    { p | currentPage = Bounded.dec 1 p.currentPage }
 
 
 {-| Go to the first page.
@@ -139,50 +141,48 @@ last paginatedList =
 {-| Useful to conditionally show a "prev" button.
 -}
 isFirst : PaginatedList a -> Bool
-isFirst (PaginatedList { currentPage }) =
-    Bounded.value currentPage == 1
+isFirst p =
+    Bounded.value p.currentPage == 1
 
 
 {-| Useful to conditionally show a "next" button.
 -}
 isLast : PaginatedList a -> Bool
-isLast (PaginatedList { currentPage }) =
-    Bounded.value currentPage == Bounded.maxBound currentPage
+isLast p =
+    Bounded.value p.currentPage == Bounded.maxBound p.currentPage
 
 
 {-| Get the length of the wrapped list.
 -}
 length : PaginatedList a -> Int
-length (PaginatedList { items }) =
-    List.length items
+length p =
+    List.length p.items
 
 
 {-| Get the current page of the `PaginatedList`.
 -}
 currentPage : PaginatedList a -> Int
-currentPage (PaginatedList { currentPage }) =
-    Bounded.value currentPage
+currentPage p =
+    Bounded.value p.currentPage
 
 
 {-| Get the number of items per page.
 -}
 itemsPerPage : PaginatedList a -> Int
-itemsPerPage (PaginatedList { itemsPerPage }) =
-    itemsPerPage
+itemsPerPage = .itemsPerPage
 
 
 {-| Get the total number of pages.
 -}
 totalPages : PaginatedList a -> Int
-totalPages (PaginatedList { currentPage }) =
-    Bounded.maxBound currentPage
+totalPages p =
+    Bounded.maxBound p.currentPage
 
 
 {-| Pull out the wrapped list (losing the pagination context).  Consider using `query` instead.
 -}
 toList : PaginatedList a -> List a
-toList (PaginatedList { items }) =
-    items
+toList = .items
 
 
 {-| Run an arbitrary function on the wrapped list (losing the pagination context).  Probably most useful for querying the list.  Or if you want to pull certain items out of pagination to making them "sticky."
@@ -197,8 +197,8 @@ toList (PaginatedList { items }) =
 
 -}
 query : (List a -> b) -> PaginatedList a -> b
-query f (PaginatedList { items }) =
-    f items
+query f p =
+    f p.items
 
 
 {-| Get the "slice" of the wrapped list for the current page.  Usually you would call this and pass the result on to your view function.
@@ -211,10 +211,10 @@ query f (PaginatedList { items }) =
 
 -}
 page : PaginatedList a -> List a
-page (PaginatedList { itemsPerPage, currentPage, items }) =
-    items
-        |> List.drop ((Bounded.value currentPage - 1) * itemsPerPage)
-        |> List.take (itemsPerPage)
+page p =
+    p.items
+        |> List.drop ((Bounded.value p.currentPage - 1) * p.itemsPerPage)
+        |> List.take (p.itemsPerPage)
 
 
 {-| Build a "pager" for your paginated list.  Usually you would use this to render the pager view.  The supplied function is given the current page number being iterated over and whether that page is the current page.
@@ -231,6 +231,6 @@ page (PaginatedList { itemsPerPage, currentPage, items }) =
 
 -}
 pager : (Int -> Bool -> b) -> PaginatedList a -> List b
-pager f (PaginatedList { currentPage }) =
-    List.range 1 (Bounded.maxBound currentPage)
-        |> List.map (\i -> f i (i == (Bounded.value currentPage)))
+pager f p =
+    List.range 1 (Bounded.maxBound p.currentPage)
+        |> List.map (\i -> f i (i == (Bounded.value p.currentPage)))


### PR DESCRIPTION
The Union type seemed to only serve as a barrier to use of record syntax. All functions in the Paginate module have been updated accordingly.