### PR TITLE
Add elided pager

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -17,6 +17,7 @@
         "elm/random": "1.0.0 <= v < 2.0.0",
         "elm/regex": "1.0.0 <= v < 2.0.0",
         "elm/time": "1.0.0 <= v < 2.0.0",
+        "elm-community/list-extra": "8.1.0 <= v < 9.0.0",
         "jschomay/elm-bounded-number": "2.0.0 <= v < 3.0.0"
     },
     "test-dependencies": {

--- a/elm.json
+++ b/elm.json
@@ -17,7 +17,6 @@
         "elm/random": "1.0.0 <= v < 2.0.0",
         "elm/regex": "1.0.0 <= v < 2.0.0",
         "elm/time": "1.0.0 <= v < 2.0.0",
-        "elm-community/list-extra": "8.1.0 <= v < 9.0.0",
         "jschomay/elm-bounded-number": "2.0.0 <= v < 3.0.0"
     },
     "test-dependencies": {

--- a/src/Paginate.elm
+++ b/src/Paginate.elm
@@ -209,8 +209,8 @@ page =
 
     fromList 2 [ 1, 2, 3, 4, 5, 6 ]
         |> next
-        |> pager (,)
-    -- equals [ (1, False), (2, True), (3, False) ]
+        |> pager (\pageNum, isCurrentPage -> ( pageNum, isCurrentPage ))
+    -- equals [ ( 1, False ), ( 2, True ), ( 3, False ) ]
 
 
     pagerView =

--- a/src/Paginate.elm
+++ b/src/Paginate.elm
@@ -4,6 +4,7 @@ module Paginate exposing
     , goTo, next, prev, first, last
     , page, allItems, foldMap
     , pager, length, currentPage, itemsPerPage, totalPages, isFirst, isLast
+    , PagerOptions, elidedPager
     )
 
 {-| Pagination for `List`'s.
@@ -33,7 +34,7 @@ module Paginate exposing
 
 Functions to help build a "pager" and useful paging data
 
-@docs pager, length, currentPage, itemsPerPage, totalPages, isFirst, isLast
+@docs pager, PagerOptions. elidedPager, length, currentPage, itemsPerPage, totalPages, isFirst, isLast
 
 -}
 
@@ -221,3 +222,60 @@ page =
 pager : (Int -> Bool -> b) -> PaginatedList a -> List b
 pager =
     Paginate.Custom.pager
+
+
+{-| `PagerOptions` is used by the `elidedPager` function to configure window sizes and output format. See `elidedPager` for examples of its use. The available options are as follows:
+
+
+### `innerWindow`
+
+The number of page numbers to display on either side of the current page number. A negative number will be treated as `0`.
+
+
+### `outerWindow`
+
+The number of page numbers to display at the beginning and end of the page numbers. `0` means that the first and last pages will not be displayed. A negative number will be treated as `0`.
+
+
+### `pageNumberView`
+
+How to display the page numbers provided by the pager.
+
+
+### `gapView`
+
+How to represent the gaps between page windows (if there are any).
+
+-}
+type alias PagerOptions a =
+    Paginate.Custom.PagerOptions a
+
+
+{-| Builds an "elided" pager, which displays a "gap" placeholder in-between the first and last page(s) and the current page, if there are enough pages to justify doing so. This is useful for large collections where the number of pages might be huge and you don't want to display all of the page numbers at once.
+
+    renderPageNumberString pageNum isCurrentPage =
+        if isCurrentPage then
+            ">" ++ String.fromInt pageNum ++ "<"
+
+        else
+            String.fromInt pageNum
+
+    pagerOptions =
+        { innerWindow = 1
+        , outerWindow = 1
+        , pageNumberView = renderPageNumberString
+        , gapView = "..."
+        }
+
+    paginatedList = fromList 2 (List.range 20) |> goTo 5
+
+    elidedPager pagerOptions paginatedList
+    --> [ "1", "...", "4", ">5<", "6", "...", "10" ]
+
+    elidedPager { pagerOptions | outerWindow = 0 } paginatedList
+    --> [ "4", ">5<", "6" ]
+
+-}
+elidedPager : PagerOptions b -> PaginatedList a -> List b
+elidedPager =
+    Paginate.Custom.elidedPager

--- a/src/Paginate.elm
+++ b/src/Paginate.elm
@@ -64,7 +64,6 @@ fromList a b =
     filtered =
         Paginate.map (List.filter isFavorited) myPaginatedList
 
-
     -- the paginated list now only contains the items matching your filter
     -- also the number of pages will update to stay in sync
     sorted =

--- a/src/Paginate/Custom.elm
+++ b/src/Paginate/Custom.elm
@@ -3,7 +3,7 @@ module Paginate.Custom exposing
     , init, map, changeItemsPerPage
     , goTo, next, prev, first, last
     , page, foldMap
-    , pager, currentPage, itemsPerPage, totalPages, isFirst, isLast
+    , pager, PagerOptions, elidedPager, currentPage, itemsPerPage, totalPages, isFirst, isLast
     )
 
 {-| Pagination for custom collection types.
@@ -35,10 +35,11 @@ Only use this module if you want to paginate something other than a `List`. This
 
 Functions to help build a "pager" and useful paging data
 
-@docs pager, currentPage, itemsPerPage, totalPages, isFirst, isLast
+@docs pager, PagerOptions, elidedPager, currentPage, itemsPerPage, totalPages, isFirst, isLast
 
 -}
 
+import List.Extra
 import Number.Bounded as Bounded exposing (Bounded)
 
 
@@ -180,3 +181,94 @@ pager : (Int -> Bool -> b) -> Paginated a -> List b
 pager f (Paginated { currentPage_ }) =
     List.range 1 (Bounded.maxBound currentPage_)
         |> List.map (\i -> f i (i == Bounded.value currentPage_))
+
+
+{-| `PagerOptions` is used by the `elidedPager` function to configure window sizes and output format. See `elidedPager` for examples of its use. The available options are as follows:
+
+
+### `innerWindow`
+
+The number of page numbers to display on either side of the current page number. A negative number will be treated as `0`.
+
+
+### `outerWindow`
+
+The number of page numbers to display at the beginning and end of the page numbers. `0` means that the first and last pages will not be displayed. A negative number will be treated as `0`.
+
+
+### `pageNumberView`
+
+How to display the page numbers provided by the pager.
+
+
+### `gapView`
+
+How to represent the gaps between page windows (if there are any).
+
+-}
+type alias PagerOptions a =
+    { innerWindow : Int, outerWindow : Int, pageNumberView : Int -> Bool -> a, gapView : a }
+
+
+{-| Builds an "elided" pager, which displays a "gap" placeholder in-between the first and last page(s) and the current page, if there are enough pages to justify doing so. This is useful for large collections where the number of pages might be huge and you don't want to display all of the page numbers at once.
+
+    renderPageNumberString pageNum isCurrentPage =
+        if isCurrentPage then
+            ">" ++ String.fromInt pageNum ++ "<"
+
+        else
+            String.fromInt pageNum
+
+    pagerOptions =
+        { innerWindow = 1
+        , outerWindow = 1
+        , pageNumberView = renderPageNumberString
+        , gapView = "..."
+        }
+
+    paginatedList = fromList 2 (List.range 20) |> goTo 5
+
+    elidedPager pagerOptions paginatedList
+    --> [ "1", "...", "4", ">5<", "6", "...", "10" ]
+
+    elidedPager { pagerOptions | innerWindow = 0, outerWindow = 0 } paginatedList
+    --> [ ">5<" ]
+
+-}
+elidedPager : PagerOptions b -> Paginated a -> List b
+elidedPager options (Paginated { currentPage_ }) =
+    let
+        currentPageNumber =
+            Bounded.value currentPage_
+
+        leftWindow =
+            if options.outerWindow <= 0 then
+                []
+
+            else
+                List.range
+                    (Bounded.minBound currentPage_)
+                    (Bounded.set (Bounded.minBound currentPage_ + (options.outerWindow - 1)) currentPage_ |> Bounded.value)
+
+        rightWindow =
+            if options.outerWindow <= 0 then
+                []
+
+            else
+                List.range
+                    (Bounded.set (Bounded.maxBound currentPage_ - (options.outerWindow - 1)) currentPage_ |> Bounded.value)
+                    (Bounded.maxBound currentPage_)
+
+        innerWindow =
+            List.range
+                (Basics.clamp (Bounded.minBound currentPage_) currentPageNumber (currentPageNumber - options.innerWindow))
+                (Basics.clamp currentPageNumber (Bounded.maxBound currentPage_) (currentPageNumber + options.innerWindow))
+    in
+    leftWindow
+        ++ innerWindow
+        ++ rightWindow
+        |> List.Extra.unique
+        |> List.Extra.groupWhile (\prevPageNum nextPageNum -> nextPageNum - prevPageNum == 1)
+        |> List.map (\( x, xs ) -> x :: xs)
+        |> List.map (List.map (\i -> options.pageNumberView i (i == currentPageNumber)))
+        |> List.Extra.intercalate [ options.gapView ]


### PR DESCRIPTION
Hi @jschomay, thank you for this library!

This PR adds an `elidedPager` function, per https://github.com/jschomay/elm-paginate/issues/6, but implemented a bit differently than was discussed there. Instead of `max` and `buffer` options, this pager uses `innerWindow` and `outerWindow` options to affect the number of pages presented on either side of the current page (the "inner window") and at the sides of the first and last pages (the "outer windows"). 

I opted for an API that requires you to pass both a page number rendering function and a "gap" rendering function (value), as I couldn't imagine a scenario in which you would want to render the windows without rendering the gaps.

The first commit in this PR implements this feature with the help of a few `List.Extra` functions, but I removed those so as not to add an additional dependency. If you think it's worth adding them back, let me know and I'll be happy to revert to that approach.

Any feedback/opinions/criticism is welcome!